### PR TITLE
Fix wrong menu name

### DIFF
--- a/_pages/en_US/pegaswitch.txt
+++ b/_pages/en_US/pegaswitch.txt
@@ -67,7 +67,7 @@ Note that these DNS servers will need to be set on each network you connect your
 
 #### Section IV - Initial Connection
 
-1. Navigate to `Internet` -> `Test Connection`
+1. Navigate to `Internet` -> `Internet Settings`
 1. Select your current network
 1. Select "Connect to this Network"
 1. If the DNS connection was successful, you will see the message "Registration is required to use this network."


### PR DESCRIPTION
Selecting a network to connect to (implied by the following instructions) is done via Internet Settings, not Connection Test.