### PR TITLE
Pegaswitch doesn't corrupt mii database

### DIFF
--- a/_pages/en_US/homebrew-launcher-(pegaswitch).txt
+++ b/_pages/en_US/homebrew-launcher-(pegaswitch).txt
@@ -17,9 +17,6 @@ If you are familiar with iOS device "jailbreaking", this idea could be considere
 Note that, while these instructions also work on firmware version 3.0.0, it would be far easier to instead follow [Homebrew Launcher (Installer)](homebrew-launcher-(installer)) for that firmware version.
 {: .notice--info}
 
-Note that the current homebrew exploit has the side-effect of corrupting your device's Mii Database upon initial installation. While this effect is harmless, it will result in the loss of any user-created Miis.
-{: .notice--warning}
-
 ### What you need
 
 * **Firmware 1.0.0:** The 1.0.0 release of [nx-hbmenu](https://github.com/switchbrew/nx-hbmenu/releases/tag/v1.0.0){:target="_blank"} (*the latest nx-hbmenu currently crashes on 1.0.0*)


### PR DESCRIPTION
That's only a problem of hbl installer on 3.0.0, and is a side-effect of using sdbcore.